### PR TITLE
Move observability into separate Maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,21 +65,7 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.micrometer.registry</groupId>
-            <artifactId>quarkus-micrometer-registry-otlp</artifactId>
-            <version>3.2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-observability-devservices-lgtm</artifactId>
-            <scope>provided</scope>
-        </dependency>
+        
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
@@ -161,6 +147,33 @@
                 <skipITs>false</skipITs>
                 <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
+        </profile>
+        <profile>
+            <id>observability</id>
+            <activation>
+                <property>
+                    <name>observability</name>
+                </property>
+            </activation>
+            <properties>
+                <quarkus.otel.logs.enabled>true</quarkus.otel.logs.enabled>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-opentelemetry</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkiverse.micrometer.registry</groupId>
+                    <artifactId>quarkus-micrometer-registry-otlp</artifactId>
+                    <version>3.2.4</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-observability-devservices-lgtm</artifactId>
+                    <scope>provided</scope>
+                </dependency>                
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-quarkus.otel.logs.enabled=true
-
-
 quarkus.langchain4j.log-requests=true
 quarkus.langchain4j.log-responses=true
 quarkus.langchain4j.chat-model.provider=ollama


### PR DESCRIPTION
The reason for doing this is that the LGTM
takes forever to startup, while not being
critical for understanding the concepts
that the repository is trying to teach

Users can opt into the observability
stack by doing:

```
mvn quarkus:dev -Dobservability
```